### PR TITLE
Adds a fix for the DiffusionAnalyzer if only a single atoms is given.

### DIFF
--- a/kinisi/displacement.py
+++ b/kinisi/displacement.py
@@ -48,7 +48,7 @@ def calculate_msd(p: parser.Parser, progress: bool = True) -> sc.Variable:
     return sc.DataArray(
         data=sc.Variable(dims=['time interval'], values=np.array(msd, dtype='float64'), variances=msd_var, unit=s.unit),
         coords={
-            'time interval': p.dt[:len(msd)],
+            'time interval': p.dt[: len(msd)],
             'n_samples': sc.array(dims=['time interval'], values=n_samples),
             'dimensionality': p.dimensionality,
         },

--- a/kinisi/displacement.py
+++ b/kinisi/displacement.py
@@ -36,6 +36,8 @@ def calculate_msd(p: parser.Parser, progress: bool = True) -> sc.Variable:
             [p.displacements['obs', di - 1], p.displacements['obs', di:] - p.displacements['obs', :-di]], 'obs'
         )
         n = (p.displacements.sizes['particle'] * p.dt_index['time interval', -1] / di).value
+        if n <= 1:
+            continue
         s = sc.sum(disp**2, 'dimension')
         m = sc.mean(s).value
         v = (sc.var(s, ddof=1) / n).value
@@ -46,7 +48,7 @@ def calculate_msd(p: parser.Parser, progress: bool = True) -> sc.Variable:
     return sc.DataArray(
         data=sc.Variable(dims=['time interval'], values=np.array(msd, dtype='float64'), variances=msd_var, unit=s.unit),
         coords={
-            'time interval': p.dt,
+            'time interval': p.dt[:len(msd)],
             'n_samples': sc.array(dims=['time interval'], values=n_samples),
             'dimensionality': p.dimensionality,
         },


### PR DESCRIPTION
If only a single atom were investigated, the MSD and variance in MSD would be found for all time intervals. This is undesirable as for the longest time interval, there will be only a single observation of the displacement and hence the variance will be `nan`. This means that the `diffusion` method would then fail. 

This is a straightforward solution that should resolve the issue. 