### PR TITLE
add `from_ase` to `ConductivityAnalyzer`

### DIFF
--- a/kinisi/conductivity_analyzer.py
+++ b/kinisi/conductivity_analyzer.py
@@ -104,6 +104,74 @@ class ConductivityAnalyzer(Analyzer):
         p._da = calculate_mstd(p.trajectory, system_particles, ionic_charge, progress)
         return p
 
+    @classmethod
+    def from_ase(
+        cls,
+        trajectory: Union['ase.io.trajectory.Trajectory', list['ase.io.trajectory.Trajectory']],
+        specie: Union[str, 'ase.Atom', None] = None,
+        time_step: VariableLikeType = None,
+        step_skip: VariableLikeType = None,
+        ionic_charge: VariableLikeType = None,
+        dtype: str | None = None,
+        dt: VariableLikeType = None,
+        dimension: str = 'xyz',
+        distance_unit: sc.Unit = sc.units.angstrom,
+        species_indices: VariableLikeType = None,
+        masses: VariableLikeType = None,
+        system_particles: int = 1,
+        progress: bool = True,
+    ) -> 'ConductivityAnalyzer':
+        """
+        Constructs the necessary :py:mod:`kinisi` objects for analysis from an ASE trajectory.
+
+        :param trajectory: The ASE trajectory or list of ASE trajectories to parse.
+        :param specie: Specie to calculate conductivity for as a String, e.g. :py:attr:`'Li'`, or an :py:class:`ase.Atom` object.
+        :param time_step: The input simulation time step, i.e., the time step for the molecular dynamics integrator. Note,
+            that this must be given as a :py:mod:`scipp`-type scalar. The unit used for the time_step, will be the unit
+            that is use for the time interval values.
+        :param step_skip: Sampling frequency of the simulation trajectory, i.e., how many time steps exist between the
+            output of the positions in the trajectory. Similar to the :py:attr:`time_step`, this parameter must be
+            a :py:mod:`scipp` scalar. The units for this scalar should be dimensionless.
+        :param ionic_charge: The ionic charge of the species of interest. This should be either a :py:mod:`scipp`
+            scalar if all of the ions have the same charge or an array of the charge for each individual ion.
+        :param dtype: If :py:attr:`trajectory` is a single ASE trajectory, this should be :py:attr:`None`. However, if
+            a list of ASE trajectories is passed, then it is necessary to identify if these constitute a series of
+            :py:attr:`consecutive` trajectories or a series of :py:attr:`identical` starting points with different
+            random seeds, in which case the `dtype` should be either :py:attr:`consecutive` or :py:attr:`identical`.
+        :param dt: Time intervals to calculate the displacements over. Optional, defaults to a :py:mod:`scipp` array
+            ranging from the smallest interval (i.e., time_step * step_skip) to the full simulation length, with
+            a step size the same as the smallest interval.
+        :param dimension: Dimension/s to find the displacement along, this should be some subset of `'xyz'` indicating
+            the axes of interest. Optional, defaults to `'xyz'`.
+        :param distance_unit: The unit of distance in the simulation input. This should be a :py:mod:`scipp` unit and
+            defaults to :py:attr:`sc.units.angstrom`.
+        :param species_indices: The indices of the species to compute the centre of mass of. Optional, defaults to
+            :py:attr:`None`, which means that all species are considered.
+        :param masses: The masses of the species to calculate the diffusion for. Optional, defaults
+            to :py:attr:`None`, which means that the masses are not considered.
+        :param system_particles: The number of system particles to average over. Note that the constitution of the
+            system particles are defined in index order, i.e., two system particles will involve splitting the
+            particles down the middle into each. Optional, defaults to :py:attr:`1`.
+        :param progress: Print progress bars to screen. Optional, defaults to :py:attr:`True`.
+
+        :returns: The :py:class:`ConductivityAnalyzer` object with the mean-squared charge displacement calculated.
+        """
+        p = super()._from_ase(
+            trajectory=trajectory,
+            specie=specie,
+            time_step=time_step,
+            step_skip=step_skip,
+            dtype=dtype,
+            dt=dt,
+            dimension=dimension,
+            distance_unit=distance_unit,
+            specie_indices=species_indices,
+            masses=masses,
+            progress=progress,
+        )
+        p._da = calculate_mstd(p.trajectory, system_particles, ionic_charge, progress)
+        return p
+
     def conductivity(
         self,
         start_dt: VariableLikeType,

--- a/kinisi/tests/test_conductivity_analyzer.py
+++ b/kinisi/tests/test_conductivity_analyzer.py
@@ -11,6 +11,7 @@ import unittest
 import warnings
 
 import scipp as sc
+from ase.io import Trajectory
 from numpy.testing import assert_almost_equal
 from pymatgen.io.vasp import Xdatcar
 from scipp.testing import assert_allclose
@@ -23,6 +24,10 @@ from kinisi.samples import Samples
 file_path = os.path.join(os.path.dirname(kinisi.__file__), 'tests/inputs/example_XDATCAR.gz')
 xd = Xdatcar(file_path)
 da_params = {'specie': 'Li', 'time_step': 2.0 * sc.Unit('ps'), 'step_skip': 50 * sc.Unit('dimensionless')}
+
+ase_file_path = os.path.join(os.path.dirname(kinisi.__file__), 'tests/inputs/example_ase.traj')
+traj = Trajectory(ase_file_path, 'r')
+ase_params = {'specie': 'Li', 'time_step': 1.0 * 1e-3 * sc.Unit('fs'), 'step_skip': 1 * sc.Unit('dimensionless')}
 
 
 class TestConductivityAnalyzer(unittest.TestCase):
@@ -75,6 +80,23 @@ class TestConductivityAnalyzer(unittest.TestCase):
             assert_almost_equal(a.mscd.values, a.da.values)
             assert_almost_equal(a.mscd.variances, a.da.variances)
             a.conductivity(0 * sc.Unit('ps'), temperature=100 * sc.Unit('K'))
+            assert isinstance(a.sigma, Samples)
+            assert a.sigma.unit == sc.Unit('mS/cm')
+            assert a.flatchain['sigma'].shape == (3200,)
+            assert a.flatchain['intercept'].shape == (3200,)
+
+    def test_from_ase(self):
+        """Test creating ConductivityAnalyzer from ASE trajectory."""
+        with warnings.catch_warnings(record=True) as _:
+            a = ConductivityAnalyzer.from_ase(
+                trajectory=traj,
+                ionic_charge=1 * sc.Unit('e'),
+                **ase_params
+            )
+            assert_allclose(a.dt, a.da.coords['time interval'])
+            assert_almost_equal(a.mscd.values, a.da.values)
+            assert_almost_equal(a.mscd.variances, a.da.variances)
+            a.conductivity(0 * sc.Unit('fs'), temperature=100 * sc.Unit('K'))
             assert isinstance(a.sigma, Samples)
             assert a.sigma.unit == sc.Unit('mS/cm')
             assert a.flatchain['sigma'].shape == (3200,)

--- a/kinisi/tests/test_conductivity_analyzer.py
+++ b/kinisi/tests/test_conductivity_analyzer.py
@@ -88,11 +88,7 @@ class TestConductivityAnalyzer(unittest.TestCase):
     def test_from_ase(self):
         """Test creating ConductivityAnalyzer from ASE trajectory."""
         with warnings.catch_warnings(record=True) as _:
-            a = ConductivityAnalyzer.from_ase(
-                trajectory=traj,
-                ionic_charge=1 * sc.Unit('e'),
-                **ase_params
-            )
+            a = ConductivityAnalyzer.from_ase(trajectory=traj, ionic_charge=1 * sc.Unit('e'), **ase_params)
             assert_allclose(a.dt, a.da.coords['time interval'])
             assert_almost_equal(a.mscd.values, a.da.values)
             assert_almost_equal(a.mscd.variances, a.da.variances)


### PR DESCRIPTION
I have added the `from_ase` method to the `ConductivityAnalyzer` class to support `list[ase.Atoms]` in addition to `xdatcar` files.